### PR TITLE
feat: 인기 랭킹 추가, 좋아요/결제 연동

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentFacade.java
@@ -1,6 +1,6 @@
 package com.loopers.application.payment;
 
-
+import com.loopers.application.popularity.PopularityService;
 import com.loopers.domain.order.OrderModel;
 import com.loopers.domain.payment.PaymentMethod;
 import com.loopers.domain.payment.PaymentModel;
@@ -22,6 +22,7 @@ public class PaymentFacade {
 
   private final PaymentPublisher publisher;
   private final PaymentOrderProcessor processor;
+  private final PopularityService popularityService;
 
   public PaymentInfo payment(PaymentCommand command) {
     try {
@@ -65,5 +66,12 @@ public class PaymentFacade {
     publisher.publish(paymentModel.getOrderNumber());
     paymentHistoryProcessor.add(paymentModel, "결제가 완료되었습니다.");
     publisher.publish(paymentModel.getId(), paymentModel.toString());
+
+    // 인기 점수 증가
+    orderModel.getOrderItems().forEach(item -> {
+      long qty = item.getQuantity();
+      long amountWon = item.getUnitPrice().multiply(java.math.BigInteger.valueOf(qty)).longValue();
+      popularityService.incrementPurchase(item.getProductId(), qty, amountWon);
+    });
   }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/popularity/LikeWeight.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/popularity/LikeWeight.java
@@ -1,0 +1,13 @@
+package com.loopers.application.popularity;
+
+public class LikeWeight {
+  private long value;
+
+  public long getValue() {
+    return value;
+  }
+
+  public void setValue(long value) {
+    this.value = value;
+  }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/popularity/PopularityCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/popularity/PopularityCommand.java
@@ -1,0 +1,10 @@
+package com.loopers.application.popularity;
+
+public final class PopularityCommand {
+  private PopularityCommand() {}
+
+  public record Entry(long productId, int score) {}
+
+  public record Rank(long productId, Integer rank, Integer score) {}
+}
+

--- a/apps/commerce-api/src/main/java/com/loopers/application/popularity/PopularityProperties.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/popularity/PopularityProperties.java
@@ -6,16 +6,9 @@ import org.springframework.stereotype.Component;
 @Component
 @ConfigurationProperties(prefix = "popularity")
 public class PopularityProperties {
-  private Weights weights = new Weights();
-  private int keyTtlHours = 24;
-
-  public Weights getWeights() {
-    return weights;
-  }
-
-  public void setWeights(Weights weights) {
-    this.weights = weights;
-  }
+  private int keyTtlHours;
+  private double scalingFactor;
+  private PopularityWeights weights;
 
   public int getKeyTtlHours() {
     return keyTtlHours;
@@ -25,34 +18,19 @@ public class PopularityProperties {
     this.keyTtlHours = keyTtlHours;
   }
 
-  public static class Weights {
-    private long like = 1;
-    private Purchase purchase = new Purchase();
+  public double getScalingFactor() {
+    return scalingFactor;
+  }
 
-    public long getLike() {
-      return like;
-    }
+  public void setScalingFactor(double scalingFactor) {
+    this.scalingFactor = scalingFactor;
+  }
 
-    public void setLike(long like) {
-      this.like = like;
-    }
+  public PopularityWeights getWeights() {
+    return weights;
+  }
 
-    public Purchase getPurchase() {
-      return purchase;
-    }
-
-    public void setPurchase(Purchase purchase) {
-      this.purchase = purchase;
-    }
-
-    public static class Purchase {
-      private long qty = 1;
-      private long amountPerKrw1000 = 1;
-
-      public long getQty() { return qty; }
-      public void setQty(long qty) { this.qty = qty; }
-      public long getAmountPerKrw1000() { return amountPerKrw1000; }
-      public void setAmountPerKrw1000(long amountPerKrw1000) { this.amountPerKrw1000 = amountPerKrw1000; }
-    }
+  public void setWeights(PopularityWeights weights) {
+    this.weights = weights;
   }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/popularity/PopularityProperties.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/popularity/PopularityProperties.java
@@ -1,0 +1,58 @@
+package com.loopers.application.popularity;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "popularity")
+public class PopularityProperties {
+  private Weights weights = new Weights();
+  private int keyTtlHours = 24;
+
+  public Weights getWeights() {
+    return weights;
+  }
+
+  public void setWeights(Weights weights) {
+    this.weights = weights;
+  }
+
+  public int getKeyTtlHours() {
+    return keyTtlHours;
+  }
+
+  public void setKeyTtlHours(int keyTtlHours) {
+    this.keyTtlHours = keyTtlHours;
+  }
+
+  public static class Weights {
+    private long like = 1;
+    private Purchase purchase = new Purchase();
+
+    public long getLike() {
+      return like;
+    }
+
+    public void setLike(long like) {
+      this.like = like;
+    }
+
+    public Purchase getPurchase() {
+      return purchase;
+    }
+
+    public void setPurchase(Purchase purchase) {
+      this.purchase = purchase;
+    }
+
+    public static class Purchase {
+      private long qty = 1;
+      private long amountPerKrw1000 = 1;
+
+      public long getQty() { return qty; }
+      public void setQty(long qty) { this.qty = qty; }
+      public long getAmountPerKrw1000() { return amountPerKrw1000; }
+      public void setAmountPerKrw1000(long amountPerKrw1000) { this.amountPerKrw1000 = amountPerKrw1000; }
+    }
+  }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/popularity/PopularityService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/popularity/PopularityService.java
@@ -1,10 +1,17 @@
 package com.loopers.application.popularity;
 
+import com.loopers.domain.catalog.product.ProductModel;
+import com.loopers.domain.catalog.product.ProductRepository;
+import com.loopers.interfaces.api.popularity.PopularityResponse;
+import java.math.BigInteger;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
@@ -14,39 +21,36 @@ public class PopularityService {
   private static final DateTimeFormatter DATE = DateTimeFormatter.ofPattern("yyyyMMdd");
   private final RedisTemplate<String, String> redis;
   private final PopularityProperties props;
+  private final ProductRepository productRepository;
 
-  public PopularityService(RedisTemplate<String, String> redis, PopularityProperties props) {
+  public PopularityService(RedisTemplate<String, String> redis, PopularityProperties props,
+                          ProductRepository productRepository) {
     this.redis = redis;
     this.props = props;
+    this.productRepository = productRepository;
   }
 
   public void incrementLike(long productId) {
     String key = keyFor(LocalDate.now());
-    incr(key, productId, props.getWeights().getLike());
+    incr(key, productId, props.getWeights().getLike().getValue());
   }
 
   public void decrementLike(long productId) {
     String key = keyFor(LocalDate.now());
-    incr(key, productId, -props.getWeights().getLike());
+    incr(key, productId, -props.getWeights().getLike().getValue());
   }
 
   public void incrementPurchase(long productId, long quantity, long amountWon) {
     String key = keyFor(LocalDate.now());
 
-    long qtyScore = props.getWeights()
-        .getPurchase()
-        .getQty() * Math.max(1, quantity);
-
+    long qtyScore = props.getWeights().getPurchase().getQty() * Math.max(1, quantity);
     long scaledAmount = Math.max(0, amountWon) / 1000;
-
-    long amountScore = props.getWeights()
-        .getPurchase()
-        .getAmountPerKrw1000() * scaledAmount;
+    long amountScore = props.getWeights().getPurchase().getAmountPerKrw1000() * scaledAmount;
 
     incr(key, productId, qtyScore + amountScore);
   }
 
-  public List<PopularityCommand.Entry> topN(int limit, LocalDate date) {
+  public PopularityResponse.TopRanking topN(int limit, LocalDate date) {
     int size = Math.max(1, Math.min(limit, 100));
 
     String key = keyFor(date == null ? LocalDate.now() : date);
@@ -54,60 +58,97 @@ public class PopularityService {
     ZSetOperations<String, String> z = redis.opsForZSet();
     var tuples = z.reverseRangeWithScores(key, 0, size - 1);
 
-    List<PopularityCommand.Entry> out = new ArrayList<>();
+    List<PopularityResponse.RankingItem> items = new ArrayList<>();
     if (tuples == null || tuples.isEmpty()) {
-      return out;
+      return new PopularityResponse.TopRanking(items);
     }
 
-    Double max = z.reverseRangeWithScores(key, 0, 0)
+    List<Long> productIds = tuples.stream()
+        .filter(t -> t.getValue() != null)
+        .map(t -> Long.parseLong(t.getValue()))
+        .toList();
+
+    Map<Long, ProductModel> productMap = productRepository.getIn(productIds)
         .stream()
-        .findFirst()
-        .map(ZSetOperations.TypedTuple::getScore)
-        .orElse(0.0);
+        .collect(Collectors.toMap(ProductModel::getId, Function.identity()));
 
-    double denom = max != null && max > 0 ? max : 1.0;
-
-    for (ZSetOperations.TypedTuple<String> t : tuples) {
+    List<ZSetOperations.TypedTuple<String>> ordered = new ArrayList<>(tuples);
+    Double prevScore = null;
+    int currentRank = 0;
+    for (ZSetOperations.TypedTuple<String> t : ordered) {
       if (t.getValue() == null || t.getScore() == null) {
         continue;
       }
 
-      int normalized = normalizeToInt(t.getScore(), denom);
-      out.add(new PopularityCommand.Entry(Long.parseLong(t.getValue()), normalized));
+      long productId = Long.parseLong(t.getValue());
+      ProductModel product = productMap.get(productId);
+      if (product == null) {
+        continue;
+      }
+
+      if (prevScore == null || Double.compare(t.getScore(), prevScore) != 0) {
+        currentRank += 1;
+        prevScore = t.getScore();
+      }
+
+      items.add(new PopularityResponse.RankingItem(
+          productId,
+          product.getName(),
+          product.getPrice(),
+          null, // imageUrl not available in ProductModel
+          currentRank
+      ));
     }
 
-    return out;
+    return new PopularityResponse.TopRanking(items);
   }
 
-  public PopularityCommand.Rank rankOf(long productId, LocalDate date) {
+  public PopularityResponse.ProductRank rankOf(long productId, LocalDate date) {
     String key = keyFor(date == null ? LocalDate.now() : date);
 
     ZSetOperations<String, String> z = redis.opsForZSet();
 
     Long rank = z.reverseRank(key, Long.toString(productId));
-    Double score = z.score(key, Long.toString(productId));
-    if (rank == null || score == null) {
-      return new PopularityCommand.Rank(productId, null, null);
+
+    List<ProductModel> products = productRepository.getIn(List.of(productId));
+    ProductModel product = products.isEmpty() ? null : products.get(0);
+
+    if (rank == null || product == null) {
+      String productName = product != null ? product.getName() : "Unknown Product";
+      BigInteger productPrice = product != null ? product.getPrice() : BigInteger.ZERO;
+      return new PopularityResponse.ProductRank(productId, productName, productPrice, null, null);
     }
 
-    Double max = z.reverseRangeWithScores(key, 0, 0)
-        .stream()
-        .findFirst()
-        .map(ZSetOperations.TypedTuple::getScore)
-        .orElse(0.0);
+    // compute dense rank: count distinct score groups up to this index
+    var upTo = z.reverseRangeWithScores(key, 0, rank);
+    int denseRank = 0;
+    if (upTo != null && !upTo.isEmpty()) {
+      Double prev = null;
+      for (ZSetOperations.TypedTuple<String> t : new ArrayList<>(upTo)) {
+        if (t.getScore() == null) continue;
+        if (prev == null || Double.compare(t.getScore(), prev) != 0) {
+          denseRank += 1;
+          prev = t.getScore();
+        }
+      }
+    }
 
-    double denom = max != null && max > 0 ? max : 1.0;
-
-    int normalized = normalizeToInt(score, denom);
-
-    return new PopularityCommand.Rank(productId, rank.intValue() + 1, normalized);
+    return new PopularityResponse.ProductRank(
+        productId,
+        product.getName(),
+        product.getPrice(),
+        null,
+        denseRank
+    );
   }
 
-  private void incr(String key, long productId, long score) {
+  private void incr(String key, long productId, long rawScore) {
     ZSetOperations<String, String> z = redis.opsForZSet();
 
-    z.incrementScore(key, Long.toString(productId), score);
+    // apply logarithmic scaling at storage time
+    double scaledScore = Math.log10(1 + Math.max(0, rawScore)) * props.getScalingFactor();
 
+    z.incrementScore(key, Long.toString(productId), scaledScore);
     redis.expire(key, java.time.Duration.ofHours(props.getKeyTtlHours()));
   }
 
@@ -116,16 +157,5 @@ public class PopularityService {
     return "pop:product:" + DATE.format(date);
   }
 
-  private int normalizeToInt(double score, double denom) {
-    double v = Math.max(0d, score / denom);
-
-    int scaled = (int) Math.round(v * 10_000d);
-
-    if (scaled < 0) return 0;
-
-    if (scaled > 10_000) return 10_000;
-
-    return scaled;
-  }
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/popularity/PopularityService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/popularity/PopularityService.java
@@ -1,0 +1,131 @@
+package com.loopers.application.popularity;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PopularityService {
+  private static final DateTimeFormatter DATE = DateTimeFormatter.ofPattern("yyyyMMdd");
+  private final RedisTemplate<String, String> redis;
+  private final PopularityProperties props;
+
+  public PopularityService(RedisTemplate<String, String> redis, PopularityProperties props) {
+    this.redis = redis;
+    this.props = props;
+  }
+
+  public void incrementLike(long productId) {
+    String key = keyFor(LocalDate.now());
+    incr(key, productId, props.getWeights().getLike());
+  }
+
+  public void decrementLike(long productId) {
+    String key = keyFor(LocalDate.now());
+    incr(key, productId, -props.getWeights().getLike());
+  }
+
+  public void incrementPurchase(long productId, long quantity, long amountWon) {
+    String key = keyFor(LocalDate.now());
+
+    long qtyScore = props.getWeights()
+        .getPurchase()
+        .getQty() * Math.max(1, quantity);
+
+    long scaledAmount = Math.max(0, amountWon) / 1000;
+
+    long amountScore = props.getWeights()
+        .getPurchase()
+        .getAmountPerKrw1000() * scaledAmount;
+
+    incr(key, productId, qtyScore + amountScore);
+  }
+
+  public List<PopularityCommand.Entry> topN(int limit, LocalDate date) {
+    int size = Math.max(1, Math.min(limit, 100));
+
+    String key = keyFor(date == null ? LocalDate.now() : date);
+
+    ZSetOperations<String, String> z = redis.opsForZSet();
+    var tuples = z.reverseRangeWithScores(key, 0, size - 1);
+
+    List<PopularityCommand.Entry> out = new ArrayList<>();
+    if (tuples == null || tuples.isEmpty()) {
+      return out;
+    }
+
+    Double max = z.reverseRangeWithScores(key, 0, 0)
+        .stream()
+        .findFirst()
+        .map(ZSetOperations.TypedTuple::getScore)
+        .orElse(0.0);
+
+    double denom = max != null && max > 0 ? max : 1.0;
+
+    for (ZSetOperations.TypedTuple<String> t : tuples) {
+      if (t.getValue() == null || t.getScore() == null) {
+        continue;
+      }
+
+      int normalized = normalizeToInt(t.getScore(), denom);
+      out.add(new PopularityCommand.Entry(Long.parseLong(t.getValue()), normalized));
+    }
+
+    return out;
+  }
+
+  public PopularityCommand.Rank rankOf(long productId, LocalDate date) {
+    String key = keyFor(date == null ? LocalDate.now() : date);
+
+    ZSetOperations<String, String> z = redis.opsForZSet();
+
+    Long rank = z.reverseRank(key, Long.toString(productId));
+    Double score = z.score(key, Long.toString(productId));
+    if (rank == null || score == null) {
+      return new PopularityCommand.Rank(productId, null, null);
+    }
+
+    Double max = z.reverseRangeWithScores(key, 0, 0)
+        .stream()
+        .findFirst()
+        .map(ZSetOperations.TypedTuple::getScore)
+        .orElse(0.0);
+
+    double denom = max != null && max > 0 ? max : 1.0;
+
+    int normalized = normalizeToInt(score, denom);
+
+    return new PopularityCommand.Rank(productId, rank.intValue() + 1, normalized);
+  }
+
+  private void incr(String key, long productId, long score) {
+    ZSetOperations<String, String> z = redis.opsForZSet();
+
+    z.incrementScore(key, Long.toString(productId), score);
+
+    redis.expire(key, java.time.Duration.ofHours(props.getKeyTtlHours()));
+  }
+
+  public String keyFor(LocalDate date) {
+    Objects.requireNonNull(date);
+    return "pop:product:" + DATE.format(date);
+  }
+
+  private int normalizeToInt(double score, double denom) {
+    double v = Math.max(0d, score / denom);
+
+    int scaled = (int) Math.round(v * 10_000d);
+
+    if (scaled < 0) return 0;
+
+    if (scaled > 10_000) return 10_000;
+
+    return scaled;
+  }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/popularity/PurchaseWeight.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/popularity/PurchaseWeight.java
@@ -1,0 +1,22 @@
+package com.loopers.application.popularity;
+
+public class PurchaseWeight {
+  private long qty;
+  private long amountPerKrw1000;
+
+  public long getQty() {
+    return qty;
+  }
+
+  public void setQty(long qty) {
+    this.qty = qty;
+  }
+
+  public long getAmountPerKrw1000() {
+    return amountPerKrw1000;
+  }
+
+  public void setAmountPerKrw1000(long amountPerKrw1000) {
+    this.amountPerKrw1000 = amountPerKrw1000;
+  }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/popularity/ViewWeight.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/popularity/ViewWeight.java
@@ -1,0 +1,13 @@
+package com.loopers.application.popularity;
+
+public class ViewWeight {
+  private long value;
+
+  public long getValue() {
+    return value;
+  }
+
+  public void setValue(long value) {
+    this.value = value;
+  }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1Controller.java
@@ -1,6 +1,7 @@
 package com.loopers.interfaces.api.like;
 
 import com.loopers.application.like.LikeFacade;
+import com.loopers.application.popularity.PopularityService;
 import com.loopers.interfaces.api.ApiResponse;
 import com.loopers.interfaces.api.like.LikeV1Dto.Get;
 import com.loopers.interfaces.api.like.LikeV1Dto.Get.Contents;
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class LikeV1Controller implements LikeV1ApiSpec {
   private final LikeFacade likeFacade;
+  private final PopularityService popularityService;
 
   @Override
   @PostMapping("/{productId}")
@@ -28,6 +30,7 @@ public class LikeV1Controller implements LikeV1ApiSpec {
       @RequestHeader("X-User-Id") String userId,
       @PathVariable Long productId) {
     likeFacade.like(userId, productId);
+    popularityService.incrementLike(productId);
     return ApiResponse.success(Response.from(userId, productId));
   }
 
@@ -37,6 +40,7 @@ public class LikeV1Controller implements LikeV1ApiSpec {
       @RequestHeader("X-User-Id") String userId,
       @PathVariable Long productId) {
     likeFacade.unlike(userId, productId);
+    popularityService.decrementLike(productId);
     return ApiResponse.success(Unregister.Response.from(userId, productId));
   }
 

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/popularity/PopularityResponse.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/popularity/PopularityResponse.java
@@ -1,0 +1,14 @@
+package com.loopers.interfaces.api.popularity;
+
+import java.math.BigInteger;
+import java.util.List;
+
+public final class PopularityResponse {
+  private PopularityResponse() {}
+
+  public record TopRanking(List<RankingItem> items) {}
+
+  public record RankingItem(long productId, String name, BigInteger price, String imageUrl, int rank) {}
+
+  public record ProductRank(long productId, String name, BigInteger price, String imageUrl, Integer rank) {}
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/popularity/PopularityV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/popularity/PopularityV1Controller.java
@@ -1,11 +1,9 @@
 package com.loopers.interfaces.api.popularity;
 
-import com.loopers.application.popularity.PopularityCommand;
 import com.loopers.application.popularity.PopularityService;
 import com.loopers.interfaces.api.ApiResponse;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -21,7 +19,7 @@ public class PopularityV1Controller {
   private final PopularityService popularityService;
 
   @GetMapping("/top")
-  public ApiResponse<List<PopularityCommand.Entry>> top(
+  public ApiResponse<PopularityResponse.TopRanking> top(
       @RequestParam(name = "limit", defaultValue = "10") int limit,
       @RequestParam(name = "date", required = false) String date
   ) {
@@ -31,7 +29,7 @@ public class PopularityV1Controller {
   }
 
   @GetMapping("/{productId}")
-  public ApiResponse<PopularityCommand.Rank> rank(
+  public ApiResponse<PopularityResponse.ProductRank> rank(
       @PathVariable("productId") long productId,
       @RequestParam(name = "date", required = false) String date
   ) {

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/popularity/PopularityV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/popularity/PopularityV1Controller.java
@@ -1,0 +1,41 @@
+package com.loopers.interfaces.api.popularity;
+
+import com.loopers.application.popularity.PopularityCommand;
+import com.loopers.application.popularity.PopularityService;
+import com.loopers.interfaces.api.ApiResponse;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/popularity")
+@RequiredArgsConstructor
+public class PopularityV1Controller {
+  private static final DateTimeFormatter DATE = DateTimeFormatter.ofPattern("yyyyMMdd");
+  private final PopularityService popularityService;
+
+  @GetMapping("/top")
+  public ApiResponse<List<PopularityCommand.Entry>> top(
+      @RequestParam(name = "limit", defaultValue = "10") int limit,
+      @RequestParam(name = "date", required = false) String date
+  ) {
+    if (limit < 1 || limit > 100) throw new IllegalArgumentException("limit out of range");
+    LocalDate d = date == null ? null : LocalDate.parse(date, DATE);
+    return ApiResponse.success(popularityService.topN(limit, d));
+  }
+
+  @GetMapping("/{productId}")
+  public ApiResponse<PopularityCommand.Rank> rank(
+      @PathVariable("productId") long productId,
+      @RequestParam(name = "date", required = false) String date
+  ) {
+    LocalDate d = date == null ? null : LocalDate.parse(date, DATE);
+    return ApiResponse.success(popularityService.rankOf(productId, d));
+  }
+}

--- a/apps/commerce-api/src/main/resources/application.yml
+++ b/apps/commerce-api/src/main/resources/application.yml
@@ -30,6 +30,14 @@ springdoc:
   swagger-ui:
     path: /swagger-ui.html
 
+popularity:
+  key-ttl-hours: 24
+  weights:
+    like: 1
+    purchase:
+      qty: 1
+      amountPerKrw1000: 1
+
 resilience4j:
   circuitbreaker:
     instances:

--- a/apps/commerce-api/src/main/resources/application.yml
+++ b/apps/commerce-api/src/main/resources/application.yml
@@ -32,11 +32,15 @@ springdoc:
 
 popularity:
   key-ttl-hours: 24
+  scaling-factor: 1000.0
   weights:
-    like: 1
+    like:
+      value: 1
     purchase:
       qty: 1
-      amountPerKrw1000: 1
+      amount-per-krw1000: 1
+    view:
+      value: 1
 
 resilience4j:
   circuitbreaker:

--- a/apps/commerce-api/src/test/java/com/loopers/application/payment/PaymentFacadePopularityTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/payment/PaymentFacadePopularityTest.java
@@ -1,0 +1,53 @@
+package com.loopers.application.payment;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.loopers.application.popularity.PopularityService;
+import com.loopers.domain.order.OrderModel;
+import com.loopers.domain.order.orderItem.OrderItemModel;
+import com.loopers.domain.payment.PaymentModel;
+import com.loopers.infrastructure.payment.PaymentOrderProcessor;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class PaymentFacadePopularityTest {
+
+  @Test
+  void increments_popularity_on_success_callback() {
+    PaymentProcessor paymentProcessor = mock(PaymentProcessor.class);
+    PaymentHistoryProcessor paymentHistoryProcessor = mock(PaymentHistoryProcessor.class);
+    PaymentStrategyFactory paymentFactory = mock(PaymentStrategyFactory.class);
+    PaymentPublisher publisher = mock(PaymentPublisher.class);
+    PaymentOrderProcessor orderProcessor = mock(PaymentOrderProcessor.class);
+    PopularityService popularityService = mock(PopularityService.class);
+
+    PaymentFacade facade = new PaymentFacade(
+        paymentProcessor,
+        paymentHistoryProcessor,
+        paymentFactory,
+        publisher,
+        orderProcessor,
+        popularityService
+    );
+
+    PaymentModel paymentModel = mock(PaymentModel.class);
+    when(paymentProcessor.get("tx1")).thenReturn(paymentModel);
+
+    OrderModel orderModel = mock(OrderModel.class);
+    OrderItemModel item = mock(OrderItemModel.class);
+    when(item.getProductId()).thenReturn(100L);
+    when(item.getQuantity()).thenReturn(3L);
+    when(item.getUnitPrice()).thenReturn(java.math.BigInteger.valueOf(5000));
+    when(orderModel.getOrderItems()).thenReturn(List.of(item));
+    when(orderProcessor.get("ord1")).thenReturn(orderModel);
+
+    PaymentCallBackCommand cmd = new PaymentCallBackCommand("tx1", "ord1", 1000L, "SUCCESS", null);
+
+    facade.callback(cmd);
+
+    verify(popularityService).incrementPurchase(eq(100L), eq(3L), eq(15000L));
+  }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/application/popularity/PopularityServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/popularity/PopularityServiceTest.java
@@ -1,0 +1,88 @@
+package com.loopers.application.popularity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import com.loopers.application.popularity.PopularityCommand;
+
+class PopularityServiceTest {
+
+  @Test
+  @DisplayName("increment like increases score by like weight")
+  void increment_like() {
+    RedisTemplate<String, String> redis = Mockito.mock(RedisTemplate.class);
+    ZSetOperations<String, String> z = Mockito.mock(ZSetOperations.class);
+    when(redis.opsForZSet()).thenReturn(z);
+    PopularityProperties props = new PopularityProperties();
+    PopularityService svc = new PopularityService(redis, props);
+
+    svc.incrementLike(101L);
+
+    verify(z).incrementScore(eq(svc.keyFor(LocalDate.now())), eq("101"), eq(1.0));
+  }
+
+  @Test
+  @DisplayName("increment purchase increases by qty and amount weights")
+  void increment_purchase() {
+    RedisTemplate<String, String> redis = Mockito.mock(RedisTemplate.class);
+    ZSetOperations<String, String> z = Mockito.mock(ZSetOperations.class);
+    when(redis.opsForZSet()).thenReturn(z);
+    PopularityProperties props = new PopularityProperties();
+    PopularityService svc = new PopularityService(redis, props);
+
+    svc.incrementPurchase(7L, 3, 5000);
+
+    // qty=3, amount=5(=5000/1000), weights default 1: 3 + 5 = 8
+    verify(z).incrementScore(eq(svc.keyFor(LocalDate.now())), eq("7"), eq(8.0));
+  }
+
+  @Test
+  @DisplayName("topN returns entries ordered with scores")
+  void topn() {
+    RedisTemplate<String, String> redis = Mockito.mock(RedisTemplate.class);
+    ZSetOperations<String, String> z = Mockito.mock(ZSetOperations.class);
+    when(redis.opsForZSet()).thenReturn(z);
+    ZSetOperations.TypedTuple<String> t1 = new ZSetOperations.TypedTuple<>() {
+      public String getValue() { return "1"; }
+      public Double getScore() { return 10.0; }
+      public int compareTo(ZSetOperations.TypedTuple<String> o) { return 0; }
+    };
+    ZSetOperations.TypedTuple<String> t2 = new ZSetOperations.TypedTuple<>() {
+      public String getValue() { return "2"; }
+      public Double getScore() { return 5.0; }
+      public int compareTo(ZSetOperations.TypedTuple<String> o) { return 0; }
+    };
+    when(z.reverseRangeWithScores(any(), eq(0L), eq(1L))).thenReturn(Set.of(t1, t2));
+    PopularityService svc = new PopularityService(redis, new PopularityProperties());
+
+    List<PopularityCommand.Entry> out = svc.topN(2, LocalDate.now());
+
+    assertThat(out).extracting("productId").containsExactlyInAnyOrder(1L, 2L);
+  }
+
+  @Test
+  @DisplayName("rankOf returns nulls when not found")
+  void rank_not_found() {
+    RedisTemplate<String, String> redis = Mockito.mock(RedisTemplate.class);
+    ZSetOperations<String, String> z = Mockito.mock(ZSetOperations.class);
+    when(redis.opsForZSet()).thenReturn(z);
+    when(z.reverseRank(any(), any())).thenReturn(null);
+    when(z.score(any(), any())).thenReturn(null);
+    PopularityService svc = new PopularityService(redis, new PopularityProperties());
+
+    PopularityCommand.Rank r = svc.rankOf(9L, LocalDate.now());
+    assertThat(r.rank()).isNull();
+    assertThat(r.score()).isNull();
+  }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/application/popularity/PopularityServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/popularity/PopularityServiceTest.java
@@ -6,6 +6,8 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 
+import com.loopers.domain.catalog.product.ProductRepository;
+import com.loopers.interfaces.api.popularity.PopularityResponse;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Set;
@@ -14,7 +16,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
-import com.loopers.application.popularity.PopularityCommand;
 
 class PopularityServiceTest {
 
@@ -25,11 +26,27 @@ class PopularityServiceTest {
     ZSetOperations<String, String> z = Mockito.mock(ZSetOperations.class);
     when(redis.opsForZSet()).thenReturn(z);
     PopularityProperties props = new PopularityProperties();
-    PopularityService svc = new PopularityService(redis, props);
+    props.setKeyTtlHours(24);
+    props.setScalingFactor(1000.0);
+    LikeWeight likeWeight = new LikeWeight();
+    likeWeight.setValue(1);
+    PurchaseWeight purchaseWeight = new PurchaseWeight();
+    purchaseWeight.setQty(1);
+    purchaseWeight.setAmountPerKrw1000(1);
+    ViewWeight viewWeight = new ViewWeight();
+    viewWeight.setValue(1);
+    PopularityWeights weights = new PopularityWeights();
+    weights.setLike(likeWeight);
+    weights.setPurchase(purchaseWeight);
+    weights.setView(viewWeight);
+    props.setWeights(weights);
+    ProductRepository productRepository = Mockito.mock(ProductRepository.class);
+    PopularityService svc = new PopularityService(redis, props, productRepository);
 
     svc.incrementLike(101L);
 
-    verify(z).incrementScore(eq(svc.keyFor(LocalDate.now())), eq("101"), eq(1.0));
+    // verify logarithmic scaling is applied: log10(1 + 1) * 1000.0 = log10(2) * 1000 ≈ 301.03
+    verify(z).incrementScore(eq(svc.keyFor(LocalDate.now())), eq("101"), eq(Math.log10(2) * 1000.0));
   }
 
   @Test
@@ -39,12 +56,28 @@ class PopularityServiceTest {
     ZSetOperations<String, String> z = Mockito.mock(ZSetOperations.class);
     when(redis.opsForZSet()).thenReturn(z);
     PopularityProperties props = new PopularityProperties();
-    PopularityService svc = new PopularityService(redis, props);
+    props.setKeyTtlHours(24);
+    props.setScalingFactor(1000.0);
+    LikeWeight likeWeight = new LikeWeight();
+    likeWeight.setValue(1);
+    PurchaseWeight purchaseWeight = new PurchaseWeight();
+    purchaseWeight.setQty(1);
+    purchaseWeight.setAmountPerKrw1000(1);
+    ViewWeight viewWeight = new ViewWeight();
+    viewWeight.setValue(1);
+    PopularityWeights weights = new PopularityWeights();
+    weights.setLike(likeWeight);
+    weights.setPurchase(purchaseWeight);
+    weights.setView(viewWeight);
+    props.setWeights(weights);
+    ProductRepository productRepository = Mockito.mock(ProductRepository.class);
+    PopularityService svc = new PopularityService(redis, props, productRepository);
 
     svc.incrementPurchase(7L, 3, 5000);
 
     // qty=3, amount=5(=5000/1000), weights default 1: 3 + 5 = 8
-    verify(z).incrementScore(eq(svc.keyFor(LocalDate.now())), eq("7"), eq(8.0));
+    // logarithmic scaling: log10(1 + 8) * 1000.0 = log10(9) * 1000 ≈ 954.24
+    verify(z).incrementScore(eq(svc.keyFor(LocalDate.now())), eq("7"), eq(Math.log10(9) * 1000.0));
   }
 
   @Test
@@ -52,7 +85,12 @@ class PopularityServiceTest {
   void topn() {
     RedisTemplate<String, String> redis = Mockito.mock(RedisTemplate.class);
     ZSetOperations<String, String> z = Mockito.mock(ZSetOperations.class);
+    ProductRepository productRepository = Mockito.mock(ProductRepository.class);
     when(redis.opsForZSet()).thenReturn(z);
+
+    // mock product data
+    when(productRepository.getIn(any())).thenReturn(List.of());
+
     ZSetOperations.TypedTuple<String> t1 = new ZSetOperations.TypedTuple<>() {
       public String getValue() { return "1"; }
       public Double getScore() { return 10.0; }
@@ -64,11 +102,28 @@ class PopularityServiceTest {
       public int compareTo(ZSetOperations.TypedTuple<String> o) { return 0; }
     };
     when(z.reverseRangeWithScores(any(), eq(0L), eq(1L))).thenReturn(Set.of(t1, t2));
-    PopularityService svc = new PopularityService(redis, new PopularityProperties());
 
-    List<PopularityCommand.Entry> out = svc.topN(2, LocalDate.now());
+    PopularityProperties props = new PopularityProperties();
+    props.setKeyTtlHours(24);
+    props.setScalingFactor(1000.0);
+    LikeWeight likeWeight = new LikeWeight();
+    likeWeight.setValue(1);
+    PurchaseWeight purchaseWeight = new PurchaseWeight();
+    purchaseWeight.setQty(1);
+    purchaseWeight.setAmountPerKrw1000(1);
+    ViewWeight viewWeight = new ViewWeight();
+    viewWeight.setValue(1);
+    PopularityWeights weights = new PopularityWeights();
+    weights.setLike(likeWeight);
+    weights.setPurchase(purchaseWeight);
+    weights.setView(viewWeight);
+    props.setWeights(weights);
+    PopularityService svc = new PopularityService(redis, props, productRepository);
 
-    assertThat(out).extracting("productId").containsExactlyInAnyOrder(1L, 2L);
+    PopularityResponse.TopRanking result = svc.topN(2, LocalDate.now());
+
+    // since no products are returned from repository, result should be empty
+    assertThat(result.items()).isEmpty();
   }
 
   @Test
@@ -76,13 +131,30 @@ class PopularityServiceTest {
   void rank_not_found() {
     RedisTemplate<String, String> redis = Mockito.mock(RedisTemplate.class);
     ZSetOperations<String, String> z = Mockito.mock(ZSetOperations.class);
+    ProductRepository productRepository = Mockito.mock(ProductRepository.class);
     when(redis.opsForZSet()).thenReturn(z);
     when(z.reverseRank(any(), any())).thenReturn(null);
-    when(z.score(any(), any())).thenReturn(null);
-    PopularityService svc = new PopularityService(redis, new PopularityProperties());
+    // score is no longer queried for API response
+    when(productRepository.getIn(any())).thenReturn(List.of());
 
-    PopularityCommand.Rank r = svc.rankOf(9L, LocalDate.now());
+    PopularityProperties props = new PopularityProperties();
+    props.setKeyTtlHours(24);
+    props.setScalingFactor(1000.0);
+    LikeWeight likeWeight = new LikeWeight();
+    likeWeight.setValue(1);
+    PurchaseWeight purchaseWeight = new PurchaseWeight();
+    purchaseWeight.setQty(1);
+    purchaseWeight.setAmountPerKrw1000(1);
+    ViewWeight viewWeight = new ViewWeight();
+    viewWeight.setValue(1);
+    PopularityWeights weights = new PopularityWeights();
+    weights.setLike(likeWeight);
+    weights.setPurchase(purchaseWeight);
+    weights.setView(viewWeight);
+    props.setWeights(weights);
+    PopularityService svc = new PopularityService(redis, props, productRepository);
+
+    PopularityResponse.ProductRank r = svc.rankOf(9L, LocalDate.now());
     assertThat(r.rank()).isNull();
-    assertThat(r.score()).isNull();
   }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/popularity/PopularityV1ControllerTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/popularity/PopularityV1ControllerTest.java
@@ -1,0 +1,45 @@
+package com.loopers.interfaces.api.popularity;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.loopers.application.popularity.PopularityService;
+import com.loopers.application.popularity.PopularityCommand;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@WebMvcTest(PopularityV1Controller.class)
+class PopularityV1ControllerTest {
+
+  @Autowired
+  MockMvc mvc;
+
+  @MockBean
+  PopularityService popularityService;
+
+  @Test
+  void top_ok() throws Exception {
+    when(popularityService.topN(any(Integer.class), any())).thenReturn(List.of(new PopularityCommand.Entry(1L, 10)));
+    mvc.perform(get("/api/v1/popularity/top").param("limit", "5"))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  void top_limit_invalid() throws Exception {
+    mvc.perform(get("/api/v1/popularity/top").param("limit", "0"))
+        .andExpect(status().is4xxClientError());
+  }
+
+  @Test
+  void rank_ok() throws Exception {
+    mvc.perform(get("/api/v1/popularity/10"))
+        .andExpect(status().isOk());
+  }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/popularity/PopularityV1ControllerTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/popularity/PopularityV1ControllerTest.java
@@ -6,27 +6,30 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.loopers.application.popularity.PopularityService;
-import com.loopers.application.popularity.PopularityCommand;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.beans.factory.annotation.Autowired;
 
 @WebMvcTest(PopularityV1Controller.class)
+@Import(MockConfig.class)
 class PopularityV1ControllerTest {
 
   @Autowired
   MockMvc mvc;
 
-  @MockBean
+  @Autowired
   PopularityService popularityService;
 
   @Test
   void top_ok() throws Exception {
-    when(popularityService.topN(any(Integer.class), any())).thenReturn(List.of(new PopularityCommand.Entry(1L, 10)));
+    when(popularityService.topN(any(Integer.class), any()))
+        .thenReturn(new PopularityResponse.TopRanking(List.of()));
     mvc.perform(get("/api/v1/popularity/top").param("limit", "5"))
         .andExpect(status().isOk());
   }
@@ -41,5 +44,13 @@ class PopularityV1ControllerTest {
   void rank_ok() throws Exception {
     mvc.perform(get("/api/v1/popularity/10"))
         .andExpect(status().isOk());
+  }
+}
+
+@TestConfiguration
+class MockConfig {
+  @Bean
+  PopularityService popularityService() {
+    return Mockito.mock(PopularityService.class);
   }
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/MetricsModel.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/MetricsModel.java
@@ -12,6 +12,8 @@ public class MetricsModel extends BaseEntity {
   private Long views;
   private Long likes;
   private Long sales;
+  // total sales amount (won) per day
+  private Long amount;
   private LocalDate date;
 
   protected MetricsModel() {
@@ -22,6 +24,16 @@ public class MetricsModel extends BaseEntity {
     this.views = views;
     this.likes = likes;
     this.sales = sales;
+    this.amount = 0L;
+    this.date = date;
+  }
+
+  public MetricsModel(Long productId, Long views, Long likes, Long sales, Long amount, LocalDate date) {
+    this.productId = productId;
+    this.views = views;
+    this.likes = likes;
+    this.sales = sales;
+    this.amount = amount == null ? 0L : amount;
     this.date = date;
   }
 
@@ -36,6 +48,10 @@ public class MetricsModel extends BaseEntity {
 
   public void updateSales(Long sales) {
     this.sales += sales;
+  }
+
+  public void updateAmount(Long amount) {
+    this.amount += amount;
   }
 
 
@@ -69,6 +85,14 @@ public class MetricsModel extends BaseEntity {
 
   public void setSales(Long sales) {
     this.sales = sales;
+  }
+
+  public Long getAmount() {
+    return amount;
+  }
+
+  public void setAmount(Long amount) {
+    this.amount = amount;
   }
 
   public LocalDate getDate() {


### PR DESCRIPTION
> ## 📌 Summary

  - Redis ZSET 기반 실시간 인기 랭킹 기능 추가
      - 키: pop:product:{yyyyMMdd} (서버 로컬 기준), TTL 24h
      - 점수: 좋아요(+1)/해제(-1), 구매(수량 가중 + 금액/1000 가중)
      - 저장: Redis에는 raw score 누적, 응답 시 0..10000 정수로 정규화
  - 공개 API
      - GET /api/v1/popularity/top?limit=10&date=yyyyMMdd
      - GET /api/v1/popularity/{productId}?date=yyyyMMdd
  - 흐름 연동
      - 좋아요 등록/취소 시 인기 점수 증감
      - 결제 콜백 성공 시 주문상품별 점수 증가

  ## 💬 Review Points

  - 설계 선택
      - 정규화 저장 vs 정규화 응답: ZSET에 raw 저장, 응답 시 당일 최고점 대비 정규화(0..10000 int)로 결정
      - 이유: 쓰기 부하/복잡도 감소(정규화 저장 시 최대값 갱신 때 재스케일 O(N) 필요)
  - 구매 점수 계산: qtyWeight * quantity + amountWeight * (amountWon / 1000)로 단순·직관적 스케일 채택
      - 수량과 금액 모두 반영, 이후 가중치 튜닝만으로 조정 가능
  - 날짜/키 전략: 서버 로컬 날짜 사용. 일자별 분리 + TTL 24h로 운영 


---
구현해 놓지 못한 코드가 너무 많아 용훈님께 양해를 구하고, 용훈님이 구현해 두신 프로젝트에 이번 주 과제만 구현했습니다.

제 코드도 시간을 내어 완성해 두겠습니다.

조금 더 힘내겠습니다!
